### PR TITLE
Use jsonlite::flatten() to flatten data frame.

### DIFF
--- a/R/api.R
+++ b/R/api.R
@@ -31,7 +31,7 @@ stack_parse <- function(req) {
     # "shallow user" ends up being a data.frame. Turn it into separate
     # columns
     if (any(sapply(items, is.data.frame))) {
-        items <- do.call(cbind, items)
+        items <- jsonlite::flatten(items)
     }
     # replace dots, as in owner.user_id, with _
     colnames(items) <- gsub("\\.", "_", colnames(items))


### PR DESCRIPTION
jsonlite::flatten() recursively flattens data frames,
while the previous code only did one level.  This
means we have a fully flat data frame that won't
crash dplyr::bind_rows.

Closes #2